### PR TITLE
Fix distribution fails because of missing docs folder

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,8 +2,7 @@ include LICENSE
 include *.rst
 include *.md
 exclude MANIFEST.in
-recursive-exclude static *
-recursive-exclude docs *
+recursive-include docs *
 recursive-include src/senaite/diagnosis *
 recursive-exclude src/senaite/diagnosis *.pyc
 recursive-exclude src/senaite/diagnosis/locales/.tx *


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ensures the dist includes the `docs` folder

Related ticket: #2 

## Current behavior before PR

The latest dist of `senaite.diagnosis` from Pypi does not work

## Desired behavior after PR is merged

The latest dist of `senaite.diagnosis` from Pypi does work

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html