### PR TITLE
Add sort for Code column on Diseases and Symptoms listings

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,7 @@ Changelog
 1.0.1 (2024-01-16)
 ------------------
 
+- #6 Add sort for Code column on Diseases and Symptoms listings
 - #3 Fix distribution fails because of missing docs folder
 
 

--- a/src/senaite/diagnosis/browser/content/diseases.py
+++ b/src/senaite/diagnosis/browser/content/diseases.py
@@ -57,7 +57,7 @@ class DiseasesListingView(ListingView):
                     "column_diseases_code",
                     default="Code"
                 ),
-                "index": "sortable_title"
+                "sortable": True,
             }),
             ("Title", {
                 "title": _p("Title"),

--- a/src/senaite/diagnosis/browser/content/symptoms.py
+++ b/src/senaite/diagnosis/browser/content/symptoms.py
@@ -57,7 +57,7 @@ class SymptomsListingView(ListingView):
                     "column_symptoms_code",
                     default="Code"
                 ),
-                "index": "sortable_title"
+                "sortable": True,
             }),
             ("Title", {
                 "title": _p("Title"),


### PR DESCRIPTION
The table is sortable on Title only. When one clicks the sort arrow next to Code it resorts on Title again
![image-20231112-080628](https://github.com/user-attachments/assets/1cf0c19e-316c-4e56-b94e-9883c02793f6)

After the PR is merged should be able to sort on the Code column
![image](https://github.com/user-attachments/assets/66d58043-12ad-4f1e-a952-2216572ff10f)

