### PR TITLE
Allow full stops in Disease and Symptom codes

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,7 @@ Changelog
 1.0.1 (2024-01-16)
 ------------------
 
+- #7 Allow full stops in Disease and Symptom codes 
 - #3 Fix distribution fails because of missing docs folder
 
 

--- a/src/senaite/diagnosis/utils.py
+++ b/src/senaite/diagnosis/utils.py
@@ -35,11 +35,11 @@ def translate(i18n_message, mapping=None):
 
 def is_valid_code(value):
     """Return whether the value can be used as code, without special characters
-    except '-' and without empties
+    except '-', '.' and without empties
     """
     if not value:
         return False
-    regex = r'^[a-zA-Z0-9\-]*$'
+    regex = r'^[a-zA-Z0-9.-]*$'
     if re.match(regex, value):
         return True
     return False


### PR DESCRIPTION
Currently doesn't allow inputing fullstops on the code field, e.g: A41.9 
![image](https://github.com/user-attachments/assets/efb0e9bc-df32-4c61-aba8-6324e78b43d2)

After the PR has be merged fullstops should allowed on the code field
![image](https://github.com/user-attachments/assets/87151b02-8234-49ff-98f2-e1148587159b)
